### PR TITLE
Add support for building under Cygwin

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,7 +1,15 @@
 # Configuration options
 #NO_EXTENSIONS=1
+ifneq ($(shell echo $$OSTYPE),cygwin)
 PYTHON_DIR = C:\\Python27
 PYTHON_INCLUDE_DIR = $(PYTHON_DIR)\\include
+PYTHON_LIB_DIR = $(PYTHON_DIR)\\lib
+PYTHON_LIB = python27
+else
+PYTHON_INCLUDE_DIR = /usr/include/python2.7
+PYTHON_LIB_DIR = /usr/lib/python2.7
+PYTHON_LIB = python2.7.dll
+endif
 
 SRC_DIR = src
 LIB_DIR = lib
@@ -37,7 +45,7 @@ SETUP_SCRIPT = src/setup-noextensions.nsi
 
 COMPILE_FLAGS = $(_COMPILE_FLAGS)
 ifndef NO_EXTENSIONS
-	PYTHON_FLAGS = -lpython27 -static -static-libgcc
+	PYTHON_FLAGS = -L$(PYTHON_LIB_DIR) -l$(PYTHON_LIB) -static -static-libgcc
 	COMPILE_FLAGS += -DEXTENSIONS_INCLUDED -I$(PYTHON_INCLUDE_DIR)
 	SETUP_SCRIPT = src/setup.nsi
 endif

--- a/src/interface_win32.c
+++ b/src/interface_win32.c
@@ -1,5 +1,7 @@
-#ifdef _WIN32
-#define NTDDI_VERSION NTDDI_WIN2K
+#if defined(_WIN32) || defined(__CYGWIN__)
+#ifndef __CYGWIN__
+    #define NTDDI_VERSION NTDDI_WIN2K
+#endif /*__CYGWIN__*/
 #define _WIN32_IE 0x0500
 #define _WIN32_WINNT 0x0500
 
@@ -7,7 +9,9 @@
     #include <windows.h>
     #include <winable.h>
     #include <shellapi.h>
-    #include <conio.h>
+    #ifndef __CYGWIN__
+        #include <conio.h>
+    #endif /*__CYGWIN__*/
     #include <Shlobj.h>
     #include <Winuser.h>
     #include <tchar.h>


### PR DESCRIPTION
Minor changes to build interface_win32.c when building with Cygwin, and some makefile changes to find the correct Python headers/library.

Note that this results in a 'Cygwin binary' (ie. depends on cygwin1.dll). Compiler options will need changing to build without this dependency (AFAIK).